### PR TITLE
cleaner code?

### DIFF
--- a/UmbracoNineDemoSite.Core/Features/Shared/Components/Hero/HeroViewComponent.cs
+++ b/UmbracoNineDemoSite.Core/Features/Shared/Components/Hero/HeroViewComponent.cs
@@ -2,8 +2,15 @@
 
 namespace UmbracoNineDemoSite.Core.Features.Shared.Components.Hero
 {
-	[ViewComponent(Name = "Hero")]
-	public class HeroComponent : ViewComponent
+	//The following two changes simplify the code according to https://docs.microsoft.com/en-us/aspnet/core/mvc/views/view-components?view=aspnetcore-5.0
+	// A view component class can be created by any of the following:
+	//	- Deriving from ViewComponent
+	//	- Decorating a class with the[ViewComponent] attribute, or deriving from a class with the[ViewComponent] attribute
+	//	- Creating a class where the name ends with the suffix ViewComponent
+
+	//[ViewComponent(Name = "Hero")]
+	//public class HeroComponent : ViewComponent
+	public class Hero : ViewComponent
 	{
 		public IViewComponentResult Invoke(HeroViewModel heroViewModel)
 		{

--- a/UmbracoNineDemoSite.Core/Features/Shared/Components/Hero/HeroViewComponent.cs
+++ b/UmbracoNineDemoSite.Core/Features/Shared/Components/Hero/HeroViewComponent.cs
@@ -2,15 +2,7 @@
 
 namespace UmbracoNineDemoSite.Core.Features.Shared.Components.Hero
 {
-	//The following two changes simplify the code according to https://docs.microsoft.com/en-us/aspnet/core/mvc/views/view-components?view=aspnetcore-5.0
-	// A view component class can be created by any of the following:
-	//	- Deriving from ViewComponent
-	//	- Decorating a class with the[ViewComponent] attribute, or deriving from a class with the[ViewComponent] attribute
-	//	- Creating a class where the name ends with the suffix ViewComponent
-
-	//[ViewComponent(Name = "Hero")]
-	//public class HeroComponent : ViewComponent
-	public class Hero : ViewComponent
+	public class HeroViewComponent : ViewComponent
 	{
 		public IViewComponentResult Invoke(HeroViewModel heroViewModel)
 		{


### PR DESCRIPTION
Hi Dennis,
I have realised that you changed my last pull request and I like to understand your intention. 
So have changed the code again and added an extra comment for explanation.

Let me explain in my own words:
My concern is about the class name _HeroComponent_.
Later on in _Web_ project you reference this class in `\Views\Home.cshtml` with:
```
@(await Component.InvokeAsync("Hero", Model.Hero))
```
This is only works when you add the attribute `[ViewComponent(Name = "Hero")]` to the class.

I can imagine one argument for the class name suffix `Component` and extra attribute:

1. This is to express the type of class by its name. 
2. And the attribute to avoid an obviously redundant expression like `[ViewComponent(Name = "HeroComponent")]`

If this is your intent, I think you should call the class _HeroViewComponent_ and omit the attribute.

Another argument for the extra attribute is to make views resilient against class name refactoring in the Core project.

For me all this has code smells🤔
Maybe I am overly pedantic or got something wrong.
Actually I just like to hear your opinion!

Btw. I got my first _ahh effect_ of mocking and testing😁

/Dirk
