### PR TITLE
Use `IComposer` instead of  `IUserComposer`

### DIFF
--- a/UmbracoNineDemoSite.Core/Features/Shared/Settings/SiteSettingsComposer.cs
+++ b/UmbracoNineDemoSite.Core/Features/Shared/Settings/SiteSettingsComposer.cs
@@ -4,8 +4,8 @@ using Umbraco.Cms.Core.DependencyInjection;
 
 namespace UmbracoNineDemoSite.Core.Features.Shared.Settings
 {
-    public class SiteSettingsComposer : IUserComposer
-	{
+    public class SiteSettingsComposer : IComposer
+    {
         public void Compose(IUmbracoBuilder builder)
         {
             builder.Services.AddTransient<ISiteSettings, SiteSettings>();


### PR DESCRIPTION
`IUserComposer` is deprecated in Umbraco v9 and should now just use `IComposer`. 😁 